### PR TITLE
bump: update coredns image for aws clusters

### DIFF
--- a/scripts/aws/coredns.yaml
+++ b/scripts/aws/coredns.yaml
@@ -117,7 +117,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
       containers:
         - name: coredns
-          image: tinden/coredns:master
+          image: coredns/coredns:1.9.1
           imagePullPolicy: IfNotPresent
           resources:
             limits:


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>


## Motivation

Corends has released image with a fix for aws clusters

https://github.com/coredns/coredns/commit/de21fb24367f1586376c48e27de3318c48b59ea3