### PR TITLE
fix: gke cannot start because  gcp authz method has been deprecated by gcloud

### DIFF
--- a/entry_point_test.go
+++ b/entry_point_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // This is required for GKE authentication
 
 	"github.com/networkservicemesh/integration-tests/suites/multicluster"
 )

--- a/gke/gke.yaml
+++ b/gke/gke.yaml
@@ -16,6 +16,7 @@ providers:
       - GKE_CLUSTER_ZONE=us-central1-a
       - GKE_CLUSTER_TYPE=n1-standard-2
       - GKE_CLUSTER_NUM_NODES=2
+      - USE_GKE_GCLOUD_AUTH_PLUGIN=true
     env-check:
       - GCLOUD_SERVICE_KEY
       - GCLOUD_PROJECT_ID

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/networkservicemesh/integration-interdomain-k8s
 go 1.18
 
 require (
-	github.com/networkservicemesh/integration-tests v0.0.0-20221219214735-370246c106f2
+	github.com/networkservicemesh/integration-tests v1.7.1
 	github.com/stretchr/testify v1.7.0
 	k8s.io/client-go v0.20.5
 )

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/networkservicemesh/gotestmd v0.0.0-20220628095933-eabbdc09e0dc h1:1L/OisEFsOyhwaqeJpYmM1nlJ2dBusUMiszPDBlUip0=
 github.com/networkservicemesh/gotestmd v0.0.0-20220628095933-eabbdc09e0dc/go.mod h1:8EWnekTRNX+NxBdTFE24WqUoM7SgJHbiafDBrIIdOmQ=
-github.com/networkservicemesh/integration-tests v0.0.0-20221219214735-370246c106f2 h1:mUTx26/F/2z4+9I1UPCh4OgeoUnTWnC6TKNeglhz6T0=
-github.com/networkservicemesh/integration-tests v0.0.0-20221219214735-370246c106f2/go.mod h1:qkqJgckg5vY5STByxzKhzhDB+TKCAU0qasuwfJ0cG+s=
+github.com/networkservicemesh/integration-tests v1.7.1 h1:K3YI2LCet8c0TN9jX+3+5JqneyxY/1AhchBU94n34FY=
+github.com/networkservicemesh/integration-tests v1.7.1/go.mod h1:qkqJgckg5vY5STByxzKhzhDB+TKCAU0qasuwfJ0cG+s=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/scripts/gke/gke-start.sh
+++ b/scripts/gke/gke-start.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 if ! gcloud container clusters list --project="${GKE_PROJECT_ID}" | grep -q ^"${GKE_CLUSTER_NAME}"; then \
+  gcloud components install gke-gcloud-auth-plugin
+  gcloud components update
   time gcloud container clusters create "${GKE_CLUSTER_NAME}" --project="${GKE_PROJECT_ID}" --machine-type="${GKE_CLUSTER_TYPE}" --num-nodes=1 --zone="${GKE_CLUSTER_ZONE}" -q; \
   echo "Writing config to ${KUBECONFIG}"; \
   gcloud container clusters get-credentials "${GKE_CLUSTER_NAME}" --project="${GKE_PROJECT_ID}" --zone="${GKE_CLUSTER_ZONE}" ; \


### PR DESCRIPTION
Signed-off-by: denis-tingaikin <denis.tingajkin@xored.com>